### PR TITLE
feat!: Make `callbacks` and `public_key` attributes public

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "slurmutils"
-version = "0.2.0"
+version = "0.3.0"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 repository = "https://github.com/canonical/slurmutils"
 authors = ["Jason C. Nucciarone <jason.nucciarone@canonical.com>"]

--- a/slurmutils/editors/_editor.py
+++ b/slurmutils/editors/_editor.py
@@ -161,7 +161,7 @@ def parse_model(line: str, pocket: Union[Dict, List], model) -> None:
         # Word in front of the first `=` denotes the parent configuration knob key.
         option, value = token.split("=", maxsplit=1)
         if hasattr(model, attr := _pascal2snake(option)):
-            if attr in model._callbacks and (callback := model._callbacks[attr].parse) is not None:
+            if attr in model.callbacks and (callback := model.callbacks[attr].parse) is not None:
                 holder.update({option: callback(value)})
             else:
                 holder.update({option: value})
@@ -195,7 +195,7 @@ def marshal_model(
         # rely on a mutable default in the function signature.
         ignore = set()
 
-    if primary_key := model._primary_key:
+    if primary_key := model.primary_key:
         attr = _pascal2snake(primary_key)
         primary_value = getattr(model, attr)
         data = {primary_key: primary_value, **model.dict()[primary_value]}
@@ -206,8 +206,8 @@ def marshal_model(
         if option not in ignore:
             if hasattr(model, attr := _pascal2snake(option)):
                 if (
-                    attr in model._callbacks
-                    and (callback := model._callbacks[attr].marshal) is not None
+                    attr in model.callbacks
+                    and (callback := model.callbacks[attr].marshal) is not None
                 ):
                     value = callback(value)
 

--- a/slurmutils/models/_model.py
+++ b/slurmutils/models/_model.py
@@ -227,7 +227,7 @@ class BaseModel(ABC):
 
     @property
     @abstractmethod
-    def _primary_key(self) -> Optional[str]:
+    def primary_key(self) -> Optional[str]:
         """Primary key for data model.
 
         A primary key is required for data models that have a unique identifier
@@ -245,7 +245,7 @@ class BaseModel(ABC):
 
     @property
     @abstractmethod
-    def _callbacks(self) -> MappingProxyType:
+    def callbacks(self) -> MappingProxyType:
         """Store callbacks.
 
         This map will be queried during parsing and marshalling to determine if

--- a/slurmutils/models/slurm.py
+++ b/slurmutils/models/slurm.py
@@ -49,8 +49,8 @@ class Node(BaseModel):
         super().__init__()
         self._register.update({kwargs.pop("NodeName"): {**kwargs}})
 
-    _primary_key = "NodeName"
-    _callbacks = MappingProxyType(
+    primary_key = "NodeName"
+    callbacks = MappingProxyType(
         {
             "cpu_spec_list": CommaSeparatorCallback,
             "features": CommaSeparatorCallback,
@@ -91,8 +91,8 @@ class DownNodes(BaseModel):
     the slurm.conf manpage. `man slurm.conf.5`
     """
 
-    _primary_key = None
-    _callbacks = MappingProxyType(
+    primary_key = None
+    callbacks = MappingProxyType(
         {
             "down_nodes": CommaSeparatorCallback,
             "reason": ReasonCallback,
@@ -115,8 +115,8 @@ class FrontendNode(BaseModel):
         super().__init__()
         self._register.update({kwargs.pop("FrontendName"): {**kwargs}})
 
-    _primary_key = "FrontendName"
-    _callbacks = MappingProxyType(
+    primary_key = "FrontendName"
+    callbacks = MappingProxyType(
         {
             "allow_groups": CommaSeparatorCallback,
             "allow_users": CommaSeparatorCallback,
@@ -148,8 +148,8 @@ class NodeSet(BaseModel):
         super().__init__()
         self._register.update({kwargs.pop("NodeSet"): {**kwargs}})
 
-    _primary_key = "NodeSet"
-    _callbacks = MappingProxyType({"nodes": CommaSeparatorCallback})
+    primary_key = "NodeSet"
+    callbacks = MappingProxyType({"nodes": CommaSeparatorCallback})
 
     node_set = property(*primary_key_descriptors())
     feature = property(*_nodeset_descriptors("Feature"))
@@ -167,8 +167,8 @@ class Partition(BaseModel):
         super().__init__()
         self._register.update({kwargs.pop("PartitionName"): {**kwargs}})
 
-    _primary_key = "PartitionName"
-    _callbacks = MappingProxyType(
+    primary_key = "PartitionName"
+    callbacks = MappingProxyType(
         {
             "alloc_nodes": CommaSeparatorCallback,
             "allow_accounts": CommaSeparatorCallback,
@@ -465,8 +465,8 @@ class SlurmConfig(BaseModel):
     the slurm.conf manpage. `man slurm.conf.5`
     """
 
-    _primary_key = None
-    _callbacks = MappingProxyType(
+    primary_key = None
+    callbacks = MappingProxyType(
         {
             "acct_storage_external_host": CommaSeparatorCallback,
             "acct_storage_param": SlurmDictCallback,

--- a/slurmutils/models/slurmdbd.py
+++ b/slurmutils/models/slurmdbd.py
@@ -32,8 +32,8 @@ class SlurmdbdConfig(BaseModel):
     the slurmdbd.conf manpage. `man slurmdbd.conf.5`
     """
 
-    _primary_key = None
-    _callbacks = MappingProxyType(
+    primary_key = None
+    callbacks = MappingProxyType(
         {
             "auth_alt_types": CommaSeparatorCallback,
             "auth_alt_parameters": SlurmDictCallback,

--- a/tox.ini
+++ b/tox.ini
@@ -63,11 +63,8 @@ commands =
 description = Publish slurmutils to PyPI using poetry.
 allowlist_externals =
     /usr/bin/rm
-    /usr/bin/poetry
 deps =
-    twine
-    setuptools
-    wheel
+    poetry
 commands =
     rm -rf {toxinidir}/dist
     poetry build


### PR DESCRIPTION
Decided to make the `callback` and `public_key` attributes "public" since I need them in the Slurm snap for processing configuration values that come in via the command line. Now linters will not complain about developers accessing the callbacks for performing additional parsing and marshalling when configuration changes come in from a different location that is not a Slurm-related configuration file.

BREAKING CHANGES: Removes the leading underscore from the `callbacks` and `private_key` attribute. This will break anyone accessing these attributes to perform operations on Slurm configuration data.