### PR TITLE
bugfix: Pass PYPI token to publish environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,8 @@ commands =
 
 [testenv:publish]
 description = Publish slurmutils to PyPI using poetry.
+passenv =
+    POETRY_PYPI_TOKEN_PYPI
 allowlist_externals =
     /usr/bin/rm
 deps =


### PR DESCRIPTION
Passing the PYPI token through the environment enables tox to publish new releases to the `slurmutils` listing on pypi. If this token is not passed, poetry will fail to upload the package.